### PR TITLE
fix: high cardinality policy_violations metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Flags:
                             Dependency-Track server address (default: http://localhost:8080 or $DEPENDENCY_TRACK_ADDR)
       --dtrack.api-key=DTRACK.API-KEY
                             Dependency-Track API key (default: $DEPENDENCY_TRACK_API_KEY)
+      --[no-]exporter.reduce-policy-cardinality  
+                            Initialize all policy_violations metric label values (can also be set with $EXPORTER_REDUCE_POLICY_CARDINALITY)
       --log.level=info      Only log messages with the given severity or above. One of: [debug, info, warn, error]
       --log.format=logfmt   Output format of log messages. One of: [logfmt, json]
       --version             Show application version.

--- a/main.go
+++ b/main.go
@@ -20,8 +20,9 @@ import (
 )
 
 const (
-	envAddress string = "DEPENDENCY_TRACK_ADDR"
-	envAPIKey  string = "DEPENDENCY_TRACK_API_KEY"
+	envAddress                         string = "DEPENDENCY_TRACK_ADDR"
+	envAPIKey                          string = "DEPENDENCY_TRACK_API_KEY"
+	envExporterReducePolicyCardinality string = "EXPORTER_REDUCE_POLICY_CARDINALITY"
 )
 
 func init() {
@@ -30,11 +31,12 @@ func init() {
 
 func main() {
 	var (
-		webConfig     = webflag.AddFlags(kingpin.CommandLine, ":9916")
-		metricsPath   = kingpin.Flag("web.metrics-path", "Path under which to expose metrics").Default("/metrics").String()
-		dtAddress     = kingpin.Flag("dtrack.address", fmt.Sprintf("Dependency-Track server address (can also be set with $%s)", envAddress)).Default("http://localhost:8080").Envar(envAddress).String()
-		dtAPIKey      = kingpin.Flag("dtrack.api-key", fmt.Sprintf("Dependency-Track API key (can also be set with $%s)", envAPIKey)).Envar(envAPIKey).Required().String()
-		promlogConfig = promlog.Config{}
+		webConfig                       = webflag.AddFlags(kingpin.CommandLine, ":9916")
+		metricsPath                     = kingpin.Flag("web.metrics-path", "Path under which to expose metrics").Default("/metrics").String()
+		dtAddress                       = kingpin.Flag("dtrack.address", fmt.Sprintf("Dependency-Track server address (can also be set with $%s)", envAddress)).Default("http://localhost:8080").Envar(envAddress).String()
+		dtAPIKey                        = kingpin.Flag("dtrack.api-key", fmt.Sprintf("Dependency-Track API key (can also be set with $%s)", envAPIKey)).Envar(envAPIKey).Required().String()
+		exporterReducePolicyCardinality = kingpin.Flag("exporter.reduce-policy-cardinality", fmt.Sprintf("Initialize all policy_violations metric label values (can also be set with $%s)", envExporterReducePolicyCardinality)).Envar(envExporterReducePolicyCardinality).Default("true").Bool()
+		promlogConfig                   = promlog.Config{}
 	)
 
 	flag.AddFlags(kingpin.CommandLine, &promlogConfig)
@@ -54,8 +56,9 @@ func main() {
 	}
 
 	e := exporter.Exporter{
-		Client: c,
-		Logger: logger,
+		Client:                  c,
+		Logger:                  logger,
+		ReducePolicyCardinality: *exporterReducePolicyCardinality,
 	}
 
 	http.HandleFunc(*metricsPath, e.HandlerFunc())


### PR DESCRIPTION
The exporter initialises all possible labels of `dependency_track_project_policy_violations` metrics which adds 72 metrics for each project.

https://github.com/jetstack/dependency-track-exporter/issues/53 has details of the rational but there are usecases where it is desirable to only have non-zero values of the metrics available.

This change adds a new argument that enables only non-zero value metrics to be returned. This flag defaults to the current behaviour so is an opt in feature.